### PR TITLE
[PR] CI 자동 테스트 커버리지 관련 추가

### DIFF
--- a/.github/workflows/workflow-dev.yml
+++ b/.github/workflows/workflow-dev.yml
@@ -2,7 +2,7 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "dev" , "build/ci-test-coverage-workflow" ]
   pull_request:
     branches: [ "dev" ]
 

--- a/.github/workflows/workflow-dev.yml
+++ b/.github/workflows/workflow-dev.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Build with Gradle Wrapper
         run: ./gradlew build
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   dependency-submission:
     runs-on: ubuntu-latest
     permissions:
@@ -44,7 +49,3 @@ jobs:
 
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.18'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
 }
 
 group = 'org.commerce'
@@ -50,3 +51,12 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+        html.required = false
+    }
+}
+
+check.dependsOn jacocoTestReport


### PR DESCRIPTION
1. Jacoco 플러그인 추가
2. 향후 테스트 커버리지 측정 자동화에 따른 뱃지 추가 해야한다.